### PR TITLE
ci: set version name from tag on production CD

### DIFF
--- a/.github/workflows/cd_android-production.yml
+++ b/.github/workflows/cd_android-production.yml
@@ -21,6 +21,8 @@ jobs:
         uses: ./.github/actions/setup-gradle
       - name: Setup Ruby
         uses: ./.github/actions/setup-ruby
+      - name: Set full version name from tag
+        run: bundle exec fastlane set_full_version_name_from_latest_tag
       - name: Generate uncommited Flutter files
         uses: ./.github/actions/generate-uncommited-flutter-files
         with:

--- a/.github/workflows/cd_regular-release.yml
+++ b/.github/workflows/cd_regular-release.yml
@@ -10,58 +10,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e-test-android:
-    name: E2E test Android app
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Flutter
-        uses: ./.github/actions/setup-flutter
-      - name: Setup Gradle
-        uses: ./.github/actions/setup-gradle
-      - name: Setup Ruby
-        uses: ./.github/actions/setup-ruby
-      - name: Generate uncommited Flutter files
-        uses: ./.github/actions/generate-uncommited-flutter-files
-        with:
-          firebase-options-dart-base64-emulator: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_EMULATOR }}
-          firebase-options-dart-base64-dev: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_DEV }}
-          firebase-options-dart-base64-prod: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_PROD }}
-      - name: Generate uncommited Flutter files for dev
-        uses: ./.github/actions/generate-uncommited-flutter-files-dev
-        with:
-          dart-defines-json-base64-dev: ${{ secrets.DART_DEFINES_JSON_BASE64_DEV }}
-      - name: Generate uncommited Android files for dev
-        uses: ./.github/actions/generate-uncommited-android-files-dev
-        with:
-          google-service-json-base64-dev: ${{ secrets.GOOGLE_SERVICE_JSON_BASE64_DEV }}
-      - name: Generate key store
-        uses: ./.github/actions/generate-key-store
-        with:
-          keystore-jks-base64: ${{ secrets.KEYSTORE_JKS_BASE64 }}
-          store-password: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
-          key-password: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
-          key-alias: ${{ secrets.KEYSTORE_KEY_ALIAS }}
-      - name: Generate automatic codes
-        run: bundle exec fastlane generate
-      - name: Generate E2E media files
-        uses: ./.github/actions/generate-e2e-media-files
-        with:
-          sample-videos-zip-url: ${{ secrets.API_TEST_SAMPLE_MOVIES_ZIP_URL }}
-      - name: Build Android dev app
-        run: flutter build apk --dart-define-from-file 'dart-defines_dev.json'
-      - uses: mobile-dev-inc/action-maestro-cloud@v1.8.0
-        with:
-          api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
-          app-file: 'build/app/outputs/flutter-apk/app-release.apk'
-          android-api-level: 33
-          device-locale: ja_JP
-          env: |
-            APP_ID_SUFFIX=.dev
+  # e2e-test-android:
+  #   name: E2E test Android app
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Setup Flutter
+  #       uses: ./.github/actions/setup-flutter
+  #     - name: Setup Gradle
+  #       uses: ./.github/actions/setup-gradle
+  #     - name: Setup Ruby
+  #       uses: ./.github/actions/setup-ruby
+  #     - name: Generate uncommited Flutter files
+  #       uses: ./.github/actions/generate-uncommited-flutter-files
+  #       with:
+  #         firebase-options-dart-base64-emulator: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_EMULATOR }}
+  #         firebase-options-dart-base64-dev: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_DEV }}
+  #         firebase-options-dart-base64-prod: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_PROD }}
+  #     - name: Generate uncommited Flutter files for dev
+  #       uses: ./.github/actions/generate-uncommited-flutter-files-dev
+  #       with:
+  #         dart-defines-json-base64-dev: ${{ secrets.DART_DEFINES_JSON_BASE64_DEV }}
+  #     - name: Generate uncommited Android files for dev
+  #       uses: ./.github/actions/generate-uncommited-android-files-dev
+  #       with:
+  #         google-service-json-base64-dev: ${{ secrets.GOOGLE_SERVICE_JSON_BASE64_DEV }}
+  #     - name: Generate key store
+  #       uses: ./.github/actions/generate-key-store
+  #       with:
+  #         keystore-jks-base64: ${{ secrets.KEYSTORE_JKS_BASE64 }}
+  #         store-password: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+  #         key-password: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+  #         key-alias: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+  #     - name: Generate automatic codes
+  #       run: bundle exec fastlane generate
+  #     - name: Generate E2E media files
+  #       uses: ./.github/actions/generate-e2e-media-files
+  #       with:
+  #         sample-videos-zip-url: ${{ secrets.API_TEST_SAMPLE_MOVIES_ZIP_URL }}
+  #     - name: Build Android dev app
+  #       run: flutter build apk --dart-define-from-file 'dart-defines_dev.json'
+  #     - uses: mobile-dev-inc/action-maestro-cloud@v1.8.0
+  #       with:
+  #         api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
+  #         app-file: 'build/app/outputs/flutter-apk/app-release.apk'
+  #         android-api-level: 33
+  #         device-locale: ja_JP
+  #         env: |
+  #           APP_ID_SUFFIX=.dev
   trigger-cd-production:
     name: Trigger CD production
     runs-on: ubuntu-latest
-    needs: e2e-test-android
+    # needs: e2e-test-android
     steps:
       - name: Generate token
         id: generate-token
@@ -91,5 +91,7 @@ jobs:
           git commit -m "${full_version_name}"
       - name: Add tag
         run: bundle exec fastlane add_release_candidate_tag
-      - name: Push back
-        run: git push --force-with-lease origin ${{ github.ref_name }} --tags
+      - name: Push back tag
+        run: |
+          latest_tag_name="$(git describe --tags --abbrev=0)"
+          git push origin "${latest_tag_name}"

--- a/.github/workflows/cd_regular-release.yml
+++ b/.github/workflows/cd_regular-release.yml
@@ -10,58 +10,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # e2e-test-android:
-  #   name: E2E test Android app
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Setup Flutter
-  #       uses: ./.github/actions/setup-flutter
-  #     - name: Setup Gradle
-  #       uses: ./.github/actions/setup-gradle
-  #     - name: Setup Ruby
-  #       uses: ./.github/actions/setup-ruby
-  #     - name: Generate uncommited Flutter files
-  #       uses: ./.github/actions/generate-uncommited-flutter-files
-  #       with:
-  #         firebase-options-dart-base64-emulator: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_EMULATOR }}
-  #         firebase-options-dart-base64-dev: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_DEV }}
-  #         firebase-options-dart-base64-prod: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_PROD }}
-  #     - name: Generate uncommited Flutter files for dev
-  #       uses: ./.github/actions/generate-uncommited-flutter-files-dev
-  #       with:
-  #         dart-defines-json-base64-dev: ${{ secrets.DART_DEFINES_JSON_BASE64_DEV }}
-  #     - name: Generate uncommited Android files for dev
-  #       uses: ./.github/actions/generate-uncommited-android-files-dev
-  #       with:
-  #         google-service-json-base64-dev: ${{ secrets.GOOGLE_SERVICE_JSON_BASE64_DEV }}
-  #     - name: Generate key store
-  #       uses: ./.github/actions/generate-key-store
-  #       with:
-  #         keystore-jks-base64: ${{ secrets.KEYSTORE_JKS_BASE64 }}
-  #         store-password: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
-  #         key-password: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
-  #         key-alias: ${{ secrets.KEYSTORE_KEY_ALIAS }}
-  #     - name: Generate automatic codes
-  #       run: bundle exec fastlane generate
-  #     - name: Generate E2E media files
-  #       uses: ./.github/actions/generate-e2e-media-files
-  #       with:
-  #         sample-videos-zip-url: ${{ secrets.API_TEST_SAMPLE_MOVIES_ZIP_URL }}
-  #     - name: Build Android dev app
-  #       run: flutter build apk --dart-define-from-file 'dart-defines_dev.json'
-  #     - uses: mobile-dev-inc/action-maestro-cloud@v1.8.0
-  #       with:
-  #         api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
-  #         app-file: 'build/app/outputs/flutter-apk/app-release.apk'
-  #         android-api-level: 33
-  #         device-locale: ja_JP
-  #         env: |
-  #           APP_ID_SUFFIX=.dev
+  e2e-test-android:
+    name: E2E test Android app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+      - name: Setup Ruby
+        uses: ./.github/actions/setup-ruby
+      - name: Generate uncommited Flutter files
+        uses: ./.github/actions/generate-uncommited-flutter-files
+        with:
+          firebase-options-dart-base64-emulator: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_EMULATOR }}
+          firebase-options-dart-base64-dev: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_DEV }}
+          firebase-options-dart-base64-prod: ${{ secrets.FIREBASE_OPTIONS_DART_BASE64_PROD }}
+      - name: Generate uncommited Flutter files for dev
+        uses: ./.github/actions/generate-uncommited-flutter-files-dev
+        with:
+          dart-defines-json-base64-dev: ${{ secrets.DART_DEFINES_JSON_BASE64_DEV }}
+      - name: Generate uncommited Android files for dev
+        uses: ./.github/actions/generate-uncommited-android-files-dev
+        with:
+          google-service-json-base64-dev: ${{ secrets.GOOGLE_SERVICE_JSON_BASE64_DEV }}
+      - name: Generate key store
+        uses: ./.github/actions/generate-key-store
+        with:
+          keystore-jks-base64: ${{ secrets.KEYSTORE_JKS_BASE64 }}
+          store-password: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+          key-password: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          key-alias: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+      - name: Generate automatic codes
+        run: bundle exec fastlane generate
+      - name: Generate E2E media files
+        uses: ./.github/actions/generate-e2e-media-files
+        with:
+          sample-videos-zip-url: ${{ secrets.API_TEST_SAMPLE_MOVIES_ZIP_URL }}
+      - name: Build Android dev app
+        run: flutter build apk --dart-define-from-file 'dart-defines_dev.json'
+      - uses: mobile-dev-inc/action-maestro-cloud@v1.8.0
+        with:
+          api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
+          app-file: 'build/app/outputs/flutter-apk/app-release.apk'
+          android-api-level: 33
+          device-locale: ja_JP
+          env: |
+            APP_ID_SUFFIX=.dev
   trigger-cd-production:
     name: Trigger CD production
     runs-on: ubuntu-latest
-    # needs: e2e-test-android
+    needs: e2e-test-android
     steps:
       - name: Generate token
         id: generate-token

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,6 +32,21 @@ lane :add_release_candidate_tag do
   )
 end
 
+desc 'Set full version name from latest tag'
+lane :set_full_version_name_from_latest_tag do
+  latest_tag_name = Dir.chdir('../') do
+    sh('git describe --tags --abbrev=0')
+  end
+
+  matched = %r{^.*/(\d+\.\d+\.\d+\+\d+)$}.match(latest_tag_name)
+
+  full_version_name = matched[1]
+
+  Dir.chdir('../') do
+    sh("dart run cider version #{full_version_name}")
+  end
+end
+
 private_lane :get_full_version_name do
   Dir.chdir('../') do
     sh('dart run cider version').chomp

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -45,6 +45,14 @@ Bump patch version
 
 Add release candidate tag
 
+### set_full_version_name_from_latest_tag
+
+```sh
+[bundle exec] fastlane set_full_version_name_from_latest_tag
+```
+
+Set full version name from latest tag
+
 ----
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved version naming by aligning it with the latest tag for better traceability.

- **Documentation**
  - Updated the documentation to include instructions on setting the full version name from the latest tag.

- **Chores**
  - Optimized Continuous Deployment workflows for Android production and regular releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->