### PR TITLE
ci: no commit when bump version

### DIFF
--- a/.github/workflows/cd_regular-release.yml
+++ b/.github/workflows/cd_regular-release.yml
@@ -84,11 +84,6 @@ jobs:
         run: bundle exec fastlane install_flutter_dependencies
       - name: Bump patch version
         run: bundle exec fastlane bump_patch_version
-      - name: Commit
-        run: |
-          git add pubspec.yaml
-          full_version_name="$(dart run cider version)"
-          git commit -m "${full_version_name}"
       - name: Add tag
         run: bundle exec fastlane add_release_candidate_tag
       - name: Push back tag


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the continuous deployment workflow by removing the steps for auto-updating `pubspec.yaml` and tagging release candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->