### PR TITLE
ci: bump version based on latest tag

### DIFF
--- a/.github/workflows/cd_regular-release.yml
+++ b/.github/workflows/cd_regular-release.yml
@@ -82,6 +82,8 @@ jobs:
         uses: ./.github/actions/setup-ruby
       - name: Install Flutter dependencies
         run: bundle exec fastlane install_flutter_dependencies
+      - name: Set full version name from tag
+        run: bundle exec fastlane set_full_version_name_from_latest_tag
       - name: Bump patch version
         run: bundle exec fastlane bump_patch_version
       - name: Add tag

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,7 +35,7 @@ end
 desc 'Set full version name from latest tag'
 lane :set_full_version_name_from_latest_tag do
   latest_tag_name = Dir.chdir('../') do
-    sh('git describe --tags --abbrev=0')
+    sh("git describe --tags --abbrev=0 --match='rc/*'")
   end
 
   matched = %r{^.*/(\d+\.\d+\.\d+\+\d+)$}.match(latest_tag_name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the continuous deployment workflow to automatically set the full version name based on the latest release candidate tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->