### PR TITLE
fix: change temporary media directory for automatically deletion

### DIFF
--- a/function/storage.py
+++ b/function/storage.py
@@ -3,6 +3,8 @@
 import os
 import tempfile
 
+from firebase_admin import storage
+
 from storage_rule import (TEMPLATE_EXTENSION, TEMPLATE_FILE_NAME,
                           THUMBNAIL_FILE_NAME)
 

--- a/function/storage.py
+++ b/function/storage.py
@@ -3,8 +3,6 @@
 import os
 import tempfile
 
-from firebase_admin import storage
-
 from storage_rule import (TEMPLATE_EXTENSION, TEMPLATE_FILE_NAME,
                           THUMBNAIL_FILE_NAME)
 
@@ -91,15 +89,17 @@ def _get_template_directory(template_id: str):
 
 
 def _get_unedited_user_media_relative_directory(uid: str):
-    user_media_parent_directory = \
-        _get_user_media_parent_relative_directory(uid=uid)
-    return f'{user_media_parent_directory}/unedited'
+    return _get_user_temporary_media_parent_relative_directory(
+        uid=uid,
+        type='unedited'
+    )
 
 
 def _get_edited_user_media_relative_directory(uid: str):
-    user_media_parent_directory = \
-        _get_user_media_parent_relative_directory(uid=uid)
-    return f'{user_media_parent_directory}/edited'
+    return _get_user_temporary_media_parent_relative_directory(
+        uid=uid,
+        type='edited'
+    )
 
 
 def _get_generated_pieces_relative_directory(uid: str):
@@ -112,6 +112,10 @@ def _get_generated_thumbnail_relative_directory(uid: str):
     user_media_parent_directory = \
         _get_user_media_parent_relative_directory(uid=uid)
     return f'{user_media_parent_directory}/generatedThumbnail'
+
+
+def _get_user_temporary_media_parent_relative_directory(uid: str, type: str):
+    return f'userTemporaryMedia/{type}/{uid}'
 
 
 def _get_user_media_parent_relative_directory(uid: str):

--- a/lib/data/service/storage_service_firebase.dart
+++ b/lib/data/service/storage_service_firebase.dart
@@ -66,7 +66,8 @@ class StorageServiceFirebase implements StorageService {
 
     final storageRef = FirebaseStorage.instance.ref();
 
-    final pathRef = storageRef.child('userMedia/$userId/edited/$fileName');
+    final pathRef =
+        storageRef.child('userTemporaryMedia/edited/$userId/$fileName');
 
     return pathRef.getDownloadURL();
   }
@@ -99,7 +100,8 @@ class StorageServiceFirebase implements StorageService {
 
     final fileExtension = extension(fileName);
 
-    final path = '/userMedia/$userId/unedited/$uploadFileId$fileExtension';
+    final path =
+        '/userTemporaryMedia/unedited/$userId/$uploadFileId$fileExtension';
 
     final pathRef = storageRef.child(path);
 
@@ -133,7 +135,8 @@ class StorageServiceFirebase implements StorageService {
 
     final fileExtension = extension(fileName);
 
-    final path = '/userMedia/$userId/edited/$uploadFileId$fileExtension';
+    final path =
+        '/userTemporaryMedia/edited/$userId/$uploadFileId$fileExtension';
 
     final pathRef = storageRef.child(path);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none"
 
-version: 1.0.6+30
+version: 1.0.7+32
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/storage.rules
+++ b/storage.rules
@@ -1,7 +1,7 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /userMedia/{userId}/unedited/{allPaths=**} {
+    match /userTemporaryMedia/unedited/{userId}/{allPaths=**} {
       allow read:
         if request.auth != null && request.auth.uid == userId;
       allow write:
@@ -9,7 +9,7 @@ service firebase.storage {
           // less than 100 MB
           request.resource.size < 100 * 1024 * 1024;
     }
-    match /userMedia/{userId}/edited/{allPaths=**} {
+    match /userTemporaryMedia/edited/{userId}/{allPaths=**} {
       allow read:
         if request.auth != null && request.auth.uid == userId;
       allow write:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the structure for temporary user media storage paths.
  
- **Documentation**
  - Updated storage rules to reflect new paths for user temporary media access and storage.

- **Style**
  - Adjusted storage reference paths in the `StorageServiceFirebase` class for consistency with new directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->