### PR TITLE
ci: disable tag triggers for CD of iOS Develop

### DIFF
--- a/.github/workflows/cd_ios-develop.yml
+++ b/.github/workflows/cd_ios-develop.yml
@@ -1,9 +1,9 @@
 name: CD / iOS Develop
 
 on:
-  push:
-    tags:
-      - "beta/*"
+  # Tag triggers are not set currently due to build failures in GitHub Actions.
+  # Waiting for macOS 14 to be available in GitHub Actions.
+  # https://github.com/github/roadmap/issues/813
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the continuous deployment workflow for iOS to remove tag triggers and included comments explaining the change due to build issues and pending macOS 14 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->