### PR TITLE
build: downgrade urllib3 from 2.1.0 to 1.26.18

### DIFF
--- a/function/requirements.txt
+++ b/function/requirements.txt
@@ -113,7 +113,9 @@ tomli==2.0.1
 typing_extensions==4.4.0
 tzdata==2023.4
 uritemplate==4.1.1
-urllib3==2.1.0
+# "'HTTPResponse' object has no attribute 'strict'" error occurs, so do not use 2.x series
+# See https://stackoverflow.com/questions/76423515/how-to-fix-poetry-error-httpresponse-object-has-no-attribute-strict for details
+urllib3==1.26.18
 watchdog==3.0.0
 Werkzeug==3.0.1
 wrapt==1.14.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated `urllib3` to version 1.26.18 to address an issue with 'HTTPResponse' object attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->