### PR TITLE
ci: disable schedule for regular release

### DIFF
--- a/.github/workflows/cd_regular-release.yml
+++ b/.github/workflows/cd_regular-release.yml
@@ -1,8 +1,6 @@
 name: CD / Regular release
 
 on:
-  schedule:
-    - cron:  "0 9 28 * *" # 13:00 JST on the 28th day of every month
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the scheduled trigger for the regular release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->