### PR TITLE
ci: split upload process to App Store for iOS into another lane

### DIFF
--- a/.github/workflows/cd_ios-production.yml
+++ b/.github/workflows/cd_ios-production.yml
@@ -52,5 +52,12 @@ jobs:
         run: |
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           echo "${{ secrets.PROVISIONING_PROFILE_PROD_APP_STORE_BASE64 }}" | base64 -d > ~/Library/MobileDevice/Provisioning\ Profiles/prod_app-store.mobileprovision
+      - name: Build prod app
+        run: bundle exec fastlane ios build_prod
       - name: Deploy prod app to App Store
-        run: bundle exec fastlane ios deploy_prod
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 360
+          max_attempts: 3
+          retry_on: error
+          command: bundle exec fastlane ios deploy_prod_without_build

--- a/.github/workflows/cd_ios-production.yml
+++ b/.github/workflows/cd_ios-production.yml
@@ -1,9 +1,6 @@
 name: CD / iOS Production
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     tags:
       - "rc/*"
@@ -26,8 +23,8 @@ jobs:
         uses: ./.github/actions/setup-cocoapods
       - name: Setup Ruby
         uses: ./.github/actions/setup-ruby
-      # - name: Set full version name from tag
-      #   run: bundle exec fastlane set_full_version_name_from_latest_tag
+      - name: Set full version name from tag
+        run: bundle exec fastlane set_full_version_name_from_latest_tag
       - name: Generate uncommited Flutter files
         uses: ./.github/actions/generate-uncommited-flutter-files
         with:

--- a/.github/workflows/cd_ios-production.yml
+++ b/.github/workflows/cd_ios-production.yml
@@ -1,6 +1,9 @@
 name: CD / iOS Production
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     tags:
       - "rc/*"
@@ -23,8 +26,8 @@ jobs:
         uses: ./.github/actions/setup-cocoapods
       - name: Setup Ruby
         uses: ./.github/actions/setup-ruby
-      - name: Set full version name from tag
-        run: bundle exec fastlane set_full_version_name_from_latest_tag
+      # - name: Set full version name from tag
+      #   run: bundle exec fastlane set_full_version_name_from_latest_tag
       - name: Generate uncommited Flutter files
         uses: ./.github/actions/generate-uncommited-flutter-files
         with:

--- a/.github/workflows/cd_ios-production.yml
+++ b/.github/workflows/cd_ios-production.yml
@@ -54,6 +54,7 @@ jobs:
           echo "${{ secrets.PROVISIONING_PROFILE_PROD_APP_STORE_BASE64 }}" | base64 -d > ~/Library/MobileDevice/Provisioning\ Profiles/prod_app-store.mobileprovision
       - name: Build prod app
         run: bundle exec fastlane ios build_prod
+      # Uploading to App Store may fail for temporary reasons, so we retry.
       - name: Deploy prod app to App Store
         uses: nick-fields/retry@v3
         with:

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -151,6 +151,14 @@ Deploy develop app to Firebase App Distribution
 
 Deploy production app to App Store Connect
 
+### ios deploy_prod_without_build
+
+```sh
+[bundle exec] fastlane ios deploy_prod_without_build
+```
+
+Deploy production app to App Store Connect. This lane does not build, so you need to build before running this lane.
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -80,6 +80,14 @@ platform :ios do
 
   desc 'Deploy production app to App Store Connect'
   lane :deploy_prod do
+    build_prod
+
+    deploy_prod_without_build
+  end
+
+  desc 'Deploy production app to App Store Connect. '\
+    'This lane does not build, so you need to build before running this lane.'
+  lane :deploy_prod_without_build do
     Dotenv.load '.env'
 
     apple_api_key_id = ENV['APPLE_API_KEY_ID'].to_s
@@ -87,7 +95,7 @@ platform :ios do
 
     app_store_connect_api_key_path = 'fastlane/app-store-connect-api-key.p8'
 
-    build_prod
+    lane_context[SharedValues::IPA_OUTPUT_PATH] = 'build/ios/ipa/うちメロ.ipa'
 
     api_key = app_store_connect_api_key(
       key_id: apple_api_key_id,

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -109,9 +109,11 @@ platform :ios do
       skip_metadata: false,
       skip_screenshots: true,
       force: true,
+      submit_for_review: true,
+      reject_if_possible: true,
+      automatic_release: true,
       submission_information: { add_id_info_uses_idfa: false },
-      precheck_include_in_app_purchases: false,
-      verify_only: true
+      precheck_include_in_app_purchases: false
     )
   end
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -109,11 +109,9 @@ platform :ios do
       skip_metadata: false,
       skip_screenshots: true,
       force: true,
-      submit_for_review: true,
-      reject_if_possible: true,
-      automatic_release: true,
       submission_information: { add_id_info_uses_idfa: false },
-      precheck_include_in_app_purchases: false
+      precheck_include_in_app_purchases: false,
+      verify_only: true
     )
   end
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none"
 
-version: 1.0.24+54
+version: 1.0.29+61
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none"
 
-version: 1.0.29+61
+version: 1.0.24+54
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new deployment flow for iOS production app, including a separate build step before deployment to the App Store.
- **Documentation**
	- Updated the `fastlane/README.md` with instructions for deploying the production app to App Store Connect without a preceding build step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->