### PR TITLE
ci: skip iOS E2E testing for regular release

### DIFF
--- a/.github/workflows/cd_regular-release.yml
+++ b/.github/workflows/cd_regular-release.yml
@@ -189,7 +189,6 @@ jobs:
     name: Trigger CD production
     runs-on: ubuntu-latest
     needs: 
-      - e2e-test-ios
       - e2e-test-android
     steps:
       - name: Generate token


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Removed the dependency on end-to-end iOS tests for triggering Continuous Deployment to production.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->