### PR TITLE
ci: use Renovate for Flutter packages instead of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,14 +28,3 @@ updates:
       interval: "daily"
       time: "06:00"
       timezone: "Asia/Tokyo"
-  - package-ecosystem: "pub"
-    directory: "/"
-    open-pull-requests-limit: 1
-    schedule:
-      interval: "daily"
-      time: "07:00"
-      timezone: "Asia/Tokyo"
-    # By default, Flutter repository is determined as a library and only version
-    # constraint updates are made, so change the versioning strategy.
-    # See https://github.com/dependabot/dependabot-core/issues/4979
-    versioning-strategy: "increase"

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "asdf",
     "gradle-wrapper",
     "pyenv",
+    "pub",
     "ruby-version",
     "terraform",
     "terraform-version"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dependabot configuration to remove support for the "pub" package ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->