### PR TITLE
ci: revert "build(deps): bump google-github-actions/deploy-cloud-functions from 2 to 3"

### DIFF
--- a/.github/workflows/cd_api-develop.yml
+++ b/.github/workflows/cd_api-develop.yml
@@ -35,7 +35,7 @@ jobs:
           service_account: ${{ secrets.DEPLOY_FUNCTIONS_SERVICE_ACCOUNT_EMAIL_DEV }}
           workload_identity_provider: ${{ secrets.DEPLOY_FUNCTIONS_WORKLOAD_IDENTITY_PROVIDER_DEV }}
       - name: Deploy detect Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'detect'
           runtime: 'python310'
@@ -48,7 +48,7 @@ jobs:
           max_instances: 1
           deploy_timeout: 600
       - name: Deploy submit Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'submit'
           runtime: 'python310'
@@ -61,7 +61,7 @@ jobs:
           max_instances: 1
           deploy_timeout: 600
       - name: Deploy piece Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'piece'
           runtime: 'python310'

--- a/.github/workflows/cd_api-production.yml
+++ b/.github/workflows/cd_api-production.yml
@@ -35,7 +35,7 @@ jobs:
           service_account: ${{ secrets.DEPLOY_FUNCTIONS_SERVICE_ACCOUNT_EMAIL_PROD }}
           workload_identity_provider: ${{ secrets.DEPLOY_FUNCTIONS_WORKLOAD_IDENTITY_PROVIDER_PROD }}
       - name: Deploy detect Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'detect'
           runtime: 'python310'
@@ -48,7 +48,7 @@ jobs:
           max_instances: 1
           deploy_timeout: 600
       - name: Deploy submit Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'submit'
           runtime: 'python310'
@@ -61,7 +61,7 @@ jobs:
           max_instances: 1
           deploy_timeout: 600
       - name: Deploy piece Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'piece'
           runtime: 'python310'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Downgraded the version of the `deploy-cloud-functions` action from `v3` to `v2` for more stable deployments to Google Cloud.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->